### PR TITLE
rename BarPosition to Position and add Enumerator

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -8,4 +8,3 @@ Tables
 IndexedTables
 IntervalSets
 Loess
-OrderedCollections

--- a/REQUIRE
+++ b/REQUIRE
@@ -8,3 +8,4 @@ Tables
 IndexedTables
 IntervalSets
 Loess
+OrderedCollections

--- a/src/StatsMakie.jl
+++ b/src/StatsMakie.jl
@@ -17,7 +17,7 @@ using Loess
 using OrderedCollections
 
 export Data, Group, Style
-export barposition
+export position
 
 include("scales.jl")
 include("group.jl")

--- a/src/StatsMakie.jl
+++ b/src/StatsMakie.jl
@@ -14,8 +14,10 @@ using Tables, IndexedTables
 using IndexedTables: AbstractIndexedTable
 using IntervalSets: Interval, endpoints
 using Loess
+using OrderedCollections
 
 export Data, Group, Style
+export barposition
 
 include("scales.jl")
 include("group.jl")

--- a/src/StatsMakie.jl
+++ b/src/StatsMakie.jl
@@ -14,7 +14,6 @@ using Tables, IndexedTables
 using IndexedTables: AbstractIndexedTable
 using IntervalSets: Interval, endpoints
 using Loess
-using OrderedCollections
 
 export Data, Group, Style
 export position

--- a/src/dodge.jl
+++ b/src/dodge.jl
@@ -1,14 +1,15 @@
-struct Enumerator{E<:Enum}
+struct Enumerator{E<:Enum, N<:NamedTuple}
     enum::Type{E}
-    instances::OrderedDict{Symbol, E}
+    instances::N
     function Enumerator(e::Type{E}) where {E<:Enum}
-        inst = OrderedDict{Symbol, E}(Symbol(i) => i for i in instances(e))
-        new{E}(e, inst)
+        inst = instances(e)
+        nt = NamedTuple{map(Symbol, inst)}(inst)
+        new{E, typeof(nt)}(e, nt)
     end
 end
 
-Base.getproperty(en::Enumerator, s::Symbol) = getindex(getfield(en, :instances), s)
-Base.propertynames(en::Enumerator) = Tuple(keys(getfield(en, :instances)))
+Base.getproperty(en::Enumerator, s::Symbol) = getproperty(getfield(en, :instances), s)
+Base.propertynames(en::Enumerator) = propertynames(getfield(en, :instances))
 
 @enum Position superimpose dodge stack
 

--- a/src/dodge.jl
+++ b/src/dodge.jl
@@ -1,4 +1,18 @@
+struct Enumerator{E<:Enum}
+    enum::Type{E}
+    instances::OrderedDict{Symbol, E}
+    function Enumerator(e::Type{E}) where {E<:Enum}
+        inst = OrderedDict{Symbol, E}(Symbol(i) => i for i in instances(e))
+        new{E}(e, inst)
+    end
+end
+
+Base.getproperty(en::Enumerator, s::Symbol) = getindex(getfield(en, :instances), s)
+Base.propertynames(en::Enumerator) = Tuple(keys(getfield(en, :instances)))
+
 @enum BarPosition superimpose dodge stack
+
+const barposition = Enumerator(BarPosition)
 
 used_attributes(P::PlotFunc, p::BarPosition, args...) =
     Tuple(union((:width, :space), used_attributes(P, args...)))

--- a/src/dodge.jl
+++ b/src/dodge.jl
@@ -10,14 +10,14 @@ end
 Base.getproperty(en::Enumerator, s::Symbol) = getindex(getfield(en, :instances), s)
 Base.propertynames(en::Enumerator) = Tuple(keys(getfield(en, :instances)))
 
-@enum BarPosition superimpose dodge stack
+@enum Position superimpose dodge stack
 
-const barposition = Enumerator(BarPosition)
+const position = Enumerator(Position)
 
-used_attributes(P::PlotFunc, p::BarPosition, args...) =
+used_attributes(P::PlotFunc, p::Position, args...) =
     Tuple(union((:width, :space), used_attributes(P, args...)))
 
-function convert_arguments(P::PlotFunc, p::BarPosition, args...;
+function convert_arguments(P::PlotFunc, p::Position, args...;
     width = automatic, space = 0.2, kwargs...)
     plotspec = to_plotspec(P, convert_arguments(P, args...; kwargs...))
     ptype = plottype(plotspec)
@@ -36,7 +36,7 @@ end
 
 series2matrix(x, xs, ys) = hcat((adjust_to_x(x, x′, y′) for (x′, y′) in zip(xs, ys))...)
 
-function convert_arguments(P::PlotFunc, p::BarPosition, pl::PlotList; width = automatic, space = 0.2)
+function convert_arguments(P::PlotFunc, p::Position, pl::PlotList; width = automatic, space = 0.2)
     xs_input = (ps[1] for ps in pl)
     ys_input = (ps[2] for ps in pl)
     n = length(pl)
@@ -73,10 +73,10 @@ function convert_arguments(P::PlotFunc, p::BarPosition, pl::PlotList; width = au
     PlotSpec{MultiplePlot}(PlotList(plts...))
 end
 
-convert_arguments(P::PlotFunc, p::BarPosition, y::AbstractMatrix; kwargs...) =
+convert_arguments(P::PlotFunc, p::Position, y::AbstractMatrix; kwargs...) =
     convert_arguments(P, p, 1:size(y, 1), y; kwargs...)
 
-function convert_arguments(P::PlotFunc, p::BarPosition, x::AbstractVector, y::AbstractMatrix;
+function convert_arguments(P::PlotFunc, p::Position, x::AbstractVector, y::AbstractMatrix;
     width = automatic, space = 0.2)
 
     n = size(y, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -113,10 +113,10 @@ end
     b_long = vec(b)
     c = [1, 1, 1, 1, 2, 2, 2, 2]
 
-    p1 = barplot(barposition.dodge, a, b)
-    p2 = barplot(barposition.dodge, b)
-    p3 = barplot(barposition.stack, a, b)
-    p4 = barplot(barposition.stack, Group(c), a_long, b_long)
+    p1 = barplot(position.dodge, a, b)
+    p2 = barplot(position.dodge, b)
+    p3 = barplot(position.stack, a, b)
+    p4 = barplot(position.stack, Group(c), a_long, b_long)
 
     @test p1[end][1][] isa PlotList
     series = p1[end][1][][1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -113,10 +113,10 @@ end
     b_long = vec(b)
     c = [1, 1, 1, 1, 2, 2, 2, 2]
 
-    p1 = barplot(StatsMakie.dodge, a, b)
-    p2 = barplot(StatsMakie.dodge, b)
-    p3 = barplot(StatsMakie.stack, a, b)
-    p4 = barplot(StatsMakie.stack, Group(c), a_long, b_long)
+    p1 = barplot(barposition.dodge, a, b)
+    p2 = barplot(barposition.dodge, b)
+    p3 = barplot(barposition.stack, a, b)
+    p4 = barplot(barposition.stack, Group(c), a_long, b_long)
 
     @test p1[end][1][] isa PlotList
     series = p1[end][1][][1]


### PR DESCRIPTION
This allows me to export `position::Enumerator{Position}` from which users can get all the options.

Say:

```julia
barplot(position.stack, x, y)
violin(position.dodge, x, y)
```

Which increases readability (over `StatsMakie.dodge`) and has tab-completion for the user to check all options.

EDIT: ups, actually `position` is exported already, may need a better word (don't like `BarPosition` as it doesn't make sense for `violin`).