### PR TITLE
allows markersize to be set in boxplot

### DIFF
--- a/src/recipes/boxplot.jl
+++ b/src/recipes/boxplot.jl
@@ -22,6 +22,7 @@ The StatPlots.jl package is licensed under the MIT "Expat" License:
         strokewidth = 1.0,
         mediancolor = :white,
         show_median = true,
+        markersize = :auto,
     )
     t[:outliercolor] = t[:color]
     t
@@ -106,11 +107,12 @@ function AbstractPlotting.plot!(plot::BoxPlot)
     medians = lift(getindex, signals, Node(3))
     boxes = lift(getindex, signals, Node(1))
     t_segments = lift(last, signals)
+
     scatter!(
         plot,
         color = plot[:outliercolor],
         strokecolor = plot[:strokecolor],
-        markersize = lift(*, width, 0.1),
+        markersize = plot[:markersize][] == :auto ? lift(*, width, 0.1) : plot[:markersize],
         strokewidth = plot[:strokewidth],
         outliers,
     )

--- a/src/recipes/boxplot.jl
+++ b/src/recipes/boxplot.jl
@@ -22,7 +22,7 @@ The StatPlots.jl package is licensed under the MIT "Expat" License:
         strokewidth = 1.0,
         mediancolor = :white,
         show_median = true,
-        markersize = :auto,
+        markersize = automatic,
     )
     t[:outliercolor] = t[:color]
     t
@@ -112,7 +112,7 @@ function AbstractPlotting.plot!(plot::BoxPlot)
         plot,
         color = plot[:outliercolor],
         strokecolor = plot[:strokecolor],
-        markersize = plot[:markersize][] == :auto ? lift(*, width, 0.1) : plot[:markersize],
+        markersize = lift((w, ms)-> ms === automatic ? w * 0.1 : ms, width, plot.markersize),
         strokewidth = plot[:strokewidth],
         outliers,
     )


### PR DESCRIPTION
because Makie now allows setting a pixel size for markers, users will probably want to override the default heuristic, which this PR still leaves in place for compatibility.
With the old version, markers appear squished in axes as MakieLayout defines them