### PR TITLE
fix bars for correct barplot

### DIFF
--- a/src/group/dodge.jl
+++ b/src/group/dodge.jl
@@ -48,8 +48,7 @@ function convert_arguments(P::PlotFunc, p::Position.Arrangement, pl::PlotList; w
             w = barwidth
             xs = xs_input
             y_mat = series2matrix(x, xs_input, ys_input)
-            y0, y1 = compute_stacked(y_mat; reverse = true)
-            y = y1 .- y0
+            y0, y = compute_stacked(y_mat; reverse = true)
             ft = y0
             ys = (adjust_to_x(x′, x, y[:, i]) for (i, x′) in enumerate(xs))
             fts = (adjust_to_x(x′, x, ft[:, i]) for (i, x′) in enumerate(xs))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,7 +190,7 @@ end
     @test series isa PlotSpec
     @test AbstractPlotting.plottype(series) <: BarPlot
     @test series[1] == [1, 2, 3, 4]
-    @test series[2] == [-1, -2, -3, -4]
+    @test series[2] == [11.0, 12.0, 13.0, 14.0]
     @test series[:fillto] == [12, 14, 16, 18]
     @test series[:width] == 0.8
 
@@ -198,7 +198,7 @@ end
     @test series isa PlotSpec
     @test AbstractPlotting.plottype(series) <: BarPlot
     @test series[1] == [1, 2, 3, 4]
-    @test series[2] == [-11, -12, -13, -14]
+    @test series[2] == [0.0, 0.0, 0.0, 0.0]
     @test series[:fillto] == [11, 12, 13, 14]
     @test series[:width] == 0.8
 
@@ -207,7 +207,7 @@ end
     @test series isa PlotSpec
     @test AbstractPlotting.plottype(series) <: BarPlot
     @test series[1] == [1, 2, 3, 4]
-    @test series[2] == [-1, -2, -3, -4]
+    @test series[2] == [11.0, 12.0, 13.0, 14.0]
     @test series[:fillto] == [12, 14, 16, 18]
     @test series[:width] == 0.8
 
@@ -215,7 +215,7 @@ end
     @test series isa PlotSpec
     @test AbstractPlotting.plottype(series) <: BarPlot
     @test series[1] == [1, 2, 3, 4]
-    @test series[2] == [-11, -12, -13, -14]
+    @test series[2] == [0.0, 0.0, 0.0, 0.0]
     @test series[:fillto] == [11, 12, 13, 14]
     @test series[:width] == 0.8
 end


### PR DESCRIPTION
When fixing barplots in https://github.com/JuliaPlots/AbstractPlotting.jl/pull/338, I noticed that StatsMakie seems to rely on the wrong behaviour...
With this fix &  https://github.com/JuliaPlots/AbstractPlotting.jl/pull/338, this code will now plot:
```julia
using DataFrames, RDatasets, StatsMakie
iris = RDatasets.dataset("datasets", "iris")
scatter(Data(iris), Group(:Species), :SepalLength, :SepalWidth)
```
![image](https://user-images.githubusercontent.com/1010467/75492161-7a105780-59b7-11ea-862a-5ca187e8d0b5.png)

This looks better than before, but still not like it used to ages ago:
![image](https://user-images.githubusercontent.com/1010467/75492180-84325600-59b7-11ea-805f-49655653aa4b.png)
Not sure if the data changed or something? I also didn't really know what I was doing when making the change :D 