### PR TITLE
Support categorical axes for sample plot types

### DIFF
--- a/src/StatsMakie.jl
+++ b/src/StatsMakie.jl
@@ -2,10 +2,11 @@ module StatsMakie
 
 using Observables
 using AbstractPlotting
-import AbstractPlotting: convert_arguments, used_attributes, plot!, combine, to_plotspec
+import AbstractPlotting: conversion_trait, convert_arguments, categoric_position, used_attributes, plot!, combine, to_plotspec
 using AbstractPlotting: plottype, Plot, PlotFunc, to_tuple
 using AbstractPlotting: node_pairs, extrema_nan, automatic, default_theme
 using AbstractPlotting: GeometryTypes
+using AbstractPlotting: ConversionTrait, el32convert, categoric_labels, categoric_range
 
 # Moved in https://github.com/JuliaGizmos/Observables.jl/pull/40
 if isdefined(Observables, :to_value)

--- a/src/StatsMakie.jl
+++ b/src/StatsMakie.jl
@@ -2,11 +2,11 @@ module StatsMakie
 
 using Observables
 using AbstractPlotting
-import AbstractPlotting: conversion_trait, convert_arguments, categoric_position, used_attributes, plot!, combine, to_plotspec
+import AbstractPlotting: conversion_trait, convert_arguments, used_attributes, plot!, combine, to_plotspec
 using AbstractPlotting: plottype, Plot, PlotFunc, to_tuple
 using AbstractPlotting: node_pairs, extrema_nan, automatic, default_theme
 using AbstractPlotting: GeometryTypes
-using AbstractPlotting: ConversionTrait, el32convert, categoric_labels, categoric_range
+using AbstractPlotting: ConversionTrait, el32convert, categoric_labels, categoric_position, categoric_range
 
 # Moved in https://github.com/JuliaGizmos/Observables.jl/pull/40
 if isdefined(Observables, :to_value)

--- a/src/group/tables.jl
+++ b/src/group/tables.jl
@@ -99,10 +99,6 @@ function map_traces(f, traces::AbstractArray{<:TraceSpec})
     map(ft, traces)
 end
 
-function categoric_position(x::AbstractString, labels::AbstractVector{<:AbstractString})
-    findfirst(l -> l == x, labels)
-end
-
 struct SampleBased <: ConversionTrait end
 
 function convert_arguments(::SampleBased, args::NTuple{N,AbstractVector{<:Number}}) where {N}

--- a/src/group/tables.jl
+++ b/src/group/tables.jl
@@ -99,6 +99,33 @@ function map_traces(f, traces::AbstractArray{<:TraceSpec})
     map(ft, traces)
 end
 
+function categoric_position(x::AbstractString, labels::AbstractVector{<:AbstractString})
+    findfirst(l -> l == x, labels)
+end
+
+struct SampleBased <: ConversionTrait end
+
+function convert_arguments(::SampleBased, args::NTuple{N,AbstractVector{<:Number}}) where {N}
+    return args
+end
+
+function convert_arguments(P::SampleBased, positions::Vararg{AbstractVector})
+    return convert_arguments(P, positions)
+end
+
+function convert_arguments(::SampleBased, positions::NTuple{N,AbstractVector}) where {N}
+    x = first(positions)
+    if any(n-> length(x) != length(n), positions)
+        error("all vector need to be same length. Found: $(length.(positions))")
+    end
+    labels = categoric_labels.(positions)
+    xyrange = categoric_range.(labels)
+    newpos = map(positions, labels) do pos,lab
+        el32convert(categoric_position.(pos, Ref(lab)))
+    end
+    PlotSpec(newpos...; tickranges = xyrange, ticklabels = labels)
+end
+
 function to_plotspec(P::PlotFunc, g::TraceSpec, uniquevalues; kwargs...)
     plotspec = to_plotspec(P, convert_arguments(P, g.output...))
     names = propertynames(g.primary)

--- a/src/recipes/boxplot.jl
+++ b/src/recipes/boxplot.jl
@@ -29,6 +29,8 @@ The StatPlots.jl package is licensed under the MIT "Expat" License:
     t
 end
 
+conversion_trait(x::Type{<:BoxPlot}) = SampleBased()
+
 _cycle(v::AbstractVector, idx::Integer) = v[mod1(idx, length(v))]
 _cycle(v, idx::Integer) = v
 

--- a/src/recipes/violin.jl
+++ b/src/recipes/violin.jl
@@ -8,6 +8,8 @@
     )
 end
 
+conversion_trait(x::Type{<:Violin}) = SampleBased()
+
 function plot!(plot::Violin)
     width, side = plot[:width], plot[:side]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,15 @@ seed!(0)
     @test plts[1] isa Scatter
     @test isempty(plts[1][1][])
 
+    # test categorical
+    a = repeat(["a", "b", "c", "d", "e"], inner = 20)
+    b = 1:100
+    p = boxplot(a, b)
+    plts = p[end].plots
+    @test length(plts) == 4
+    @test plts[1] isa Scatter
+    @test isempty(plts[1][1][])
+
     @test plts[2] isa LineSegments
     pts = Point{2, Float32}[
         [1.0, 5.75], [1.0, 1.0], [0.6, 1.0], [1.4, 1.0], [1.0, 15.25],
@@ -422,6 +431,16 @@ end
 @testset "violin" begin
     x = repeat(1:4, 250)
     y = x .+ randn.()
+    p = violin(x, y, side = :left, color = :blue)
+    @test p[end] isa Violin
+    @test p[end].plots[1] isa Mesh
+    @test p[end].plots[1][:color][] == :blue
+    @test p[end].plots[2] isa LineSegments
+    @test p[end].plots[2][:color][] == :white
+    @test p[end].plots[2][:visible][] == :false
+
+    # test categorical
+    x = repeat(["a", "b", "c", "d"], 250)
     p = violin(x, y, side = :left, color = :blue)
     @test p[end] isa Violin
     @test p[end].plots[1] isa Mesh


### PR DESCRIPTION
This PR adds a new conversion trait `SampleBased` that behaves similarly to `PointBased` but does not make points. This supports categorical axes. For now the only plot types deemed `SampleBased` are `Violin` and `BoxPlot`.

Some examples:

```julia
julia> a = repeat(["a", "b", "c", "d", "e"], inner = 20)

julia> b = 1:100

julia> boxplot(a, b)
```
![test](https://user-images.githubusercontent.com/8673634/75860743-2f288280-5db1-11ea-94aa-abf21af73d24.png)

However, it looks like the information about tick labels is lost when using `MultiplePlot`:

```julia
julia> using RDatasets

julia> d = dataset("Ecdat","Fatality");

julia> first(d, 1)
1×10 DataFrame
│ Row │ State │ Year  │ MRAll   │ BeerTax │ MLDA    │ JailD        │ Comserd      │ VMiles  │ Unrate  │ Perinc  │
│     │ Int32 │ Int32 │ Float64 │ Float64 │ Float64 │ Categorical… │ Categorical… │ Float64 │ Float64 │ Float64 │
├─────┼───────┼───────┼─────────┼─────────┼─────────┼──────────────┼──────────────┼─────────┼─────────┼─────────┤
│ 1   │ 1     │ 1982  │ 2.12836 │ 1.53938 │ 19.0    │ no           │ no           │ 7.23389 │ 14.4    │ 10544.2 │

julia> boxplot(Data(d), :JailD, :BeerTax)
```
![test2](https://user-images.githubusercontent.com/8673634/75860757-3354a000-5db1-11ea-82b9-a20b224f3078.png)

The function `categoric_position` is just a placeholder, as a method with a signature like this should be in AbstractPlotting.